### PR TITLE
Make Field.to_string() and Field.from_string() methods more consistent.

### DIFF
--- a/xblock/fields.py
+++ b/xblock/fields.py
@@ -590,7 +590,7 @@ class Field(Nameable):
         """
         self._warn_deprecated_outside_JSONField()
         value = yaml.safe_load(serialized)
-        return self._check_or_enforce_type(value)
+        return self.enforce_type(value)
 
     def enforce_type(self, value):
         """
@@ -602,7 +602,7 @@ class Field(Nameable):
         This must not have side effects, since it will be executed to trigger
         a DeprecationWarning even if enforce_type is disabled
         """
-        return value
+        return self.from_json(value)
 
     def read_from(self, xblock):
         """
@@ -686,8 +686,6 @@ class Integer(JSONField):
             return None
         return int(value)
 
-    enforce_type = from_json
-
 
 class Float(JSONField):
     """
@@ -704,8 +702,6 @@ class Float(JSONField):
         if value is None or value == '':
             return None
         return float(value)
-
-    enforce_type = from_json
 
 
 class Boolean(JSONField):
@@ -743,8 +739,6 @@ class Boolean(JSONField):
         else:
             return bool(value)
 
-    enforce_type = from_json
-
 
 class Dict(JSONField):
     """
@@ -764,8 +758,6 @@ class Dict(JSONField):
             raise TypeError('Value stored in a Dict must be None or a dict, found %s' % type(value))
         return value
 
-    enforce_type = from_json
-
 
 class List(JSONField):
     """
@@ -784,8 +776,6 @@ class List(JSONField):
         else:
             raise TypeError('Value stored in a List must be None or a list, found %s' % type(value))
         return value
-
-    enforce_type = from_json
 
 
 class String(JSONField):
@@ -811,8 +801,6 @@ class String(JSONField):
         """String gets serialized and deserialized without quote marks."""
         return self.to_json(value)
 
-    enforce_type = from_json
-
 
 class DateTime(JSONField):
     """
@@ -828,31 +816,27 @@ class DateTime(JSONField):
         """
         Parse the date from an ISO-formatted date string, or None.
         """
-        if isinstance(value, basestring):
-
-            # Parser interprets empty string as now by default
-            if value == "":
-                return None
-
-            try:
-                parsed_date = dateutil.parser.parse(value)
-            except (TypeError, ValueError):
-                raise ValueError("Could not parse {} as a date".format(value))
-
-            if parsed_date.tzinfo is not None:  # pylint: disable=maybe-no-member
-                parsed_date.astimezone(pytz.utc)  # pylint: disable=maybe-no-member
-            else:
-                parsed_date = parsed_date.replace(tzinfo=pytz.utc)  # pylint: disable=maybe-no-member
-
-            return parsed_date
-
         if value is None:
             return None
 
-        if isinstance(value, datetime.datetime):
-            return value
+        if isinstance(value, basestring):
+            # Parser interprets empty string as now by default
+            if value == "":
+                return None
+            try:
+                value = dateutil.parser.parse(value)
+            except (TypeError, ValueError):
+                raise ValueError("Could not parse {} as a date".format(value))
 
-        raise TypeError("Value should be loaded from a string, not {}".format(type(value)))
+        if not isinstance(value, datetime.datetime):
+            raise TypeError(
+                "Value should be loaded from a string, a datetime object or None, not {}".format(type(value))
+            )
+
+        if value.tzinfo is not None:  # pylint: disable=maybe-no-member
+            return value.astimezone(pytz.utc)  # pylint: disable=maybe-no-member
+        else:
+            return value.replace(tzinfo=pytz.utc)  # pylint: disable=maybe-no-member
 
     def to_json(self, value):
         """
@@ -864,11 +848,9 @@ class DateTime(JSONField):
             return None
         raise TypeError("Value stored must be a datetime object, not {}".format(type(value)))
 
-    def enforce_type(self, value):
-        if isinstance(value, datetime.datetime) or value is None:
-            return value
-
-        return self.from_json(value)
+    def to_string(self, value):
+        """DateTime fields get serialized without quote marks."""
+        return self.to_json(value)
 
 
 class Any(JSONField):

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -588,14 +588,14 @@ class FieldSerializationTest(unittest.TestCase):
         """
         Helper method: checks if _type's to_string given instance of _type returns expected string
         """
-        result = _type(enforce_type=True).to_string(value)
+        result = _type().to_string(value)
         self.assertEquals(result, string)
 
     def assert_from_string(self, _type, string, value):
         """
         Helper method: checks if _type's from_string given string representation of type returns expected value
         """
-        result = _type(enforce_type=True).from_string(string)
+        result = _type().from_string(string)
         self.assertEquals(result, value)
 
     @ddt.unpack
@@ -636,7 +636,10 @@ class FieldSerializationTest(unittest.TestCase):
                 2,
                 3
               ]
-            }""")))
+            }""")),
+        (DateTime, dt.datetime(2014, 4, 1, 2, 3, 4, 567890).replace(tzinfo=pytz.utc), '2014-04-01T02:03:04.567890'),
+        (DateTime, dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc), '2014-04-01T02:03:04.000000'),
+    )
     def test_both_directions(self, _type, value, string):
         """Easy cases that work in both directions."""
         self.assert_to_string(_type, value, string)
@@ -648,7 +651,7 @@ class FieldSerializationTest(unittest.TestCase):
         (Float, 1.0, r"1|1\.0*"),
         (Float, -10.0, r"-10|-10\.0*"))
     def test_to_string_regexp_matches(self, _type, value, regexp):
-        result = _type(enforce_type=True).to_string(value)
+        result = _type().to_string(value)
         self.assertRegexpMatches(result, regexp)
 
     @ddt.unpack
@@ -716,7 +719,11 @@ class FieldSerializationTest(unittest.TestCase):
                   kaw: null
             """),
             [1, 2.345, {"foo": True, "bar": [1, 2, 3]}, {"meow": False, "woof": True, "kaw": None}]
-        )
+        ),
+        # Test that legacy DateTime format including double quotes can still be imported for compatibility with
+        # old data export tar balls.
+        (DateTime, '"2014-04-01T02:03:04.567890"', dt.datetime(2014, 4, 1, 2, 3, 4, 567890).replace(tzinfo=pytz.utc)),
+        (DateTime, '"2014-04-01T02:03:04.000000"', dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc)),
     )
     def test_from_string(self, _type, string, value):
         self.assert_from_string(_type, string, value)
@@ -727,7 +734,7 @@ class FieldSerializationTest(unittest.TestCase):
         This special test case is necessary since
         float('nan') compares inequal to everything.
         """
-        result = Float(enforce_type=True).from_string('NaN')
+        result = Float().from_string('NaN')
         self.assertTrue(math.isnan(result))
 
     @ddt.unpack
@@ -737,4 +744,4 @@ class FieldSerializationTest(unittest.TestCase):
     def test_from_string_errors(self, _type, string):
         """ Cases that raises various exceptions."""
         with self.assertRaises(StandardError):
-            _type(enforce_type=True).from_string(string)
+            _type().from_string(string)


### PR DESCRIPTION
The old version of these methods was inherently assymmetric.  The deserialisation in from_string()
only called from_json() when enforce_type() was overridden to do so (which all classes with a
non-trivial from_json() implementation do) and enable_enforce_type was set to True.  This commit
makes the two functions more consistent by not considering enable_enforce_type at all for
deserialisation and calling from_json() in enforce_type() by default.  Serialisation and
deserialisation requires correct types to work already, so there is no harm in always enforciing
the type – the code fails in the same cases as before.

This commit fixes a bug in serialising DateTime fields.  The old version included spurious double
quotes around the string, which would not be correctly deserialised when enable_enforce_type was
not set (the default).