### PR TITLE
Force export runtime option + some tests for XmlSerializationMixin

### DIFF
--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -474,7 +474,7 @@ class XmlSerializationMixin(ScopedStorageMixin):
         for field_name, field in self.fields.iteritems():
             if field_name in ('children', 'parent', 'content'):
                 continue
-            if field.is_set_on(self):
+            if field.is_set_on(self) or field.runtime_options.get('force_export', False):
                 self._add_field(node, field_name, field)
 
         # Add children for each of our children.

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -1,11 +1,15 @@
 """
 Tests of the XBlock-family functionality mixins
 """
-
+from lxml import etree
+import mock
 from unittest import TestCase
 
-from xblock.fields import List, Scope, Integer
+from xblock.core import XBlock
+from xblock.fields import List, Scope, Integer, String, ScopeIds, UNIQUE_ID
+from xblock.field_data import DictFieldData
 from xblock.mixins import ScopedStorageMixin, HierarchyMixin, IndexInfoMixin
+from xblock.runtime import Runtime
 
 
 class AttrAssertionMixin(TestCase):
@@ -133,3 +137,70 @@ class TestIndexInfoMixin(AttrAssertionMixin):
         with_index_info = self.IndexInfoMixinTester().index_dictionary()
         self.assertFalse(with_index_info)
         self.assertTrue(isinstance(with_index_info, dict))
+
+
+class TestXmlSerializationMixin(TestCase):
+    """ Tests for XmlSerialization Mixin """
+
+    etree_node_tag = 'test_xblock'
+
+    class TestXBlock(XBlock):
+        """ XBlock for XML export test """
+        field = String()
+        simple_default = String(default="default")
+        simple_default_with_force_export = String(default="default", force_export=True)
+        unique_id_default = String(default=UNIQUE_ID)
+        unique_id_default_with_force_export = String(default=UNIQUE_ID, force_export=True)
+
+    def _make_block(self):
+        """ Creates a test block """
+        runtime_mock = mock.Mock(spec=Runtime)
+        scope_ids = ScopeIds("user_id", self.etree_node_tag, "def_id",  "usage_id")
+        return self.TestXBlock(runtime_mock, field_data=DictFieldData({}), scope_ids=scope_ids)
+
+    def _assert_node_attributes(self, node, attributes):
+        node_attributes = node.keys()
+        node_attributes.remove('xblock-family')
+
+        self.assertEqual(node.get('xblock-family'), self.TestXBlock.entry_point)
+
+        self.assertEqual(set(node_attributes), set(attributes.keys()))
+
+        for key, value in attributes.iteritems():
+            if value != UNIQUE_ID:
+                self.assertEqual(node.get(key), value)
+            else:
+                self.assertIsNotNone(node.get(key))
+
+    def test_add_xml_to_node(self):
+        block = self._make_block()
+        node = etree.Element(self.etree_node_tag)
+
+        # precondition check
+        for field_name in block.fields.keys():
+            self.assertFalse(block.fields[field_name].is_set_on(block))
+
+        block.add_xml_to_node(node)
+
+        self._assert_node_attributes(
+            node, {'simple_default_with_force_export': 'default', 'unique_id_default_with_force_export': UNIQUE_ID}
+        )
+
+        block.field = 'Value1'
+        block.simple_default = 'Value2'
+        block.simple_default_with_force_export = 'Value3'
+        block.unique_id_default = 'Value4'
+        block.unique_id_default_with_force_export = 'Value5'
+
+        block.add_xml_to_node(node)
+
+        self._assert_node_attributes(
+            node,
+            {
+                'field': 'Value1',
+                'simple_default': 'Value2',
+                'simple_default_with_force_export': 'Value3',
+                'unique_id_default': 'Value4',
+                'unique_id_default_with_force_export': 'Value5',
+            }
+        )


### PR DESCRIPTION
**Description:** This PR adds an option to force export any field.

The motivation is the following: `UNIQUE_ID` sentinel is used to generate a unique pseudo-random value for an XBlock field. The value generated is not actually random, and is stable (i.e. subsequent calculations return same value for given field and XBlock instances). The problem though, is that this value is not persisted in export-import workflow.

Direct motivation, more details and discussion of various approaches can be seen in the appropriate [JIRA task](https://edx-wiki.atlassian.net/browse/MCKIN-3637)

**JIRA Task:** [MCKIN-3637](https://edx-wiki.atlassian.net/browse/MCKIN-3637).
**Testing instructions:** 
No user facing parts - running unittests should be enough.

For manual verification:
1. Create an XBlock with any field that have `default=UNIQUE_ID` and `force_export=True` (or use existing one, i.e. https://github.com/open-craft/xblock-group-project-v2). 
2. Create a course, add that XBlock to course content, *do not specify a value for that field - leave it default*, but note the value somehow (i.e. display it in the student view)
3. Export course.
4. Import course. Observe the value was preserved.