### PR TITLE
Fixing exporting DateTime with value set to None

### DIFF
--- a/xblock/mixins.py
+++ b/xblock/mixins.py
@@ -516,6 +516,10 @@ class XmlSerializationMixin(ScopedStorageMixin):
         as an xml attribute or creates a separate child node.
         """
         value = field.to_string(field.read_from(self))
+
+        if value is None:
+            value = ""
+
         if field.xml_node:
             tag = etree.QName(XML_NAMESPACES["option"], field_name)
             elem = node.makeelement(tag)

--- a/xblock/test/test_fields.py
+++ b/xblock/test/test_fields.py
@@ -679,6 +679,13 @@ class FieldSerializationTest(unittest.TestCase):
 
     @ddt.unpack
     @ddt.data(
+        (DateTime, None, None)
+    )
+    def test_to_string(self, _type, value, string):
+        self.assert_to_string(_type, value, string)
+
+    @ddt.unpack
+    @ddt.data(
         (Integer, 0, '0'),
         (Integer, 5, '5'),
         (Integer, -1023, '-1023'),
@@ -803,6 +810,7 @@ class FieldSerializationTest(unittest.TestCase):
         # old data export tar balls.
         (DateTime, '"2014-04-01T02:03:04.567890"', dt.datetime(2014, 4, 1, 2, 3, 4, 567890).replace(tzinfo=pytz.utc)),
         (DateTime, '"2014-04-01T02:03:04.000000"', dt.datetime(2014, 4, 1, 2, 3, 4).replace(tzinfo=pytz.utc)),
+        (DateTime, '', None),
     )
     def test_from_string(self, _type, string, value):
         self.assert_from_string(_type, string, value)

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -1,12 +1,15 @@
 """
 Tests of the XBlock-family functionality mixins
 """
+import ddt as ddt
+from datetime import datetime
+import pytz
 from lxml import etree
 import mock
 from unittest import TestCase
 
 from xblock.core import XBlock
-from xblock.fields import List, Scope, Integer, String, ScopeIds, UNIQUE_ID
+from xblock.fields import List, Scope, Integer, String, ScopeIds, UNIQUE_ID, DateTime
 from xblock.field_data import DictFieldData
 from xblock.mixins import ScopedStorageMixin, HierarchyMixin, IndexInfoMixin
 from xblock.runtime import Runtime
@@ -139,31 +142,37 @@ class TestIndexInfoMixin(AttrAssertionMixin):
         self.assertTrue(isinstance(with_index_info, dict))
 
 
+@ddt.ddt
 class TestXmlSerializationMixin(TestCase):
     """ Tests for XmlSerialization Mixin """
 
-    etree_node_tag = 'test_xblock'
-
     class TestXBlock(XBlock):
         """ XBlock for XML export test """
+        etree_node_tag = 'test_xblock'
+
         field = String()
         simple_default = String(default="default")
         simple_default_with_force_export = String(default="default", force_export=True)
         unique_id_default = String(default=UNIQUE_ID)
         unique_id_default_with_force_export = String(default=UNIQUE_ID, force_export=True)
 
-    def _make_block(self):
+    class TestXBlockWithDateTime(XBlock):
+        etree_node_tag = 'test_xblock_with_datetime'
+
+        datetime = DateTime(default=None)
+
+    def _make_block(self, block_type=None):
         """ Creates a test block """
+        block_type = block_type if block_type else self.TestXBlock
         runtime_mock = mock.Mock(spec=Runtime)
-        scope_ids = ScopeIds("user_id", self.etree_node_tag, "def_id",  "usage_id")
-        return self.TestXBlock(runtime_mock, field_data=DictFieldData({}), scope_ids=scope_ids)
+        scope_ids = ScopeIds("user_id", block_type.etree_node_tag, "def_id",  "usage_id")
+        return block_type(runtime_mock, field_data=DictFieldData({}), scope_ids=scope_ids)
 
     def _assert_node_attributes(self, node, attributes):
         node_attributes = node.keys()
         node_attributes.remove('xblock-family')
 
         self.assertEqual(node.get('xblock-family'), self.TestXBlock.entry_point)
-
         self.assertEqual(set(node_attributes), set(attributes.keys()))
 
         for key, value in attributes.iteritems():
@@ -173,8 +182,9 @@ class TestXmlSerializationMixin(TestCase):
                 self.assertIsNotNone(node.get(key))
 
     def test_add_xml_to_node(self):
-        block = self._make_block()
-        node = etree.Element(self.etree_node_tag)
+        block_type = self.TestXBlock
+        block = self._make_block(block_type)
+        node = etree.Element(block_type.etree_node_tag)
 
         # precondition check
         for field_name in block.fields.keys():
@@ -204,3 +214,19 @@ class TestXmlSerializationMixin(TestCase):
                 'unique_id_default_with_force_export': 'Value5',
             }
         )
+
+    @ddt.data(
+        (None, {'datetime': ''}),
+        (datetime(2014, 4, 1, 2, 3, 4, 567890).replace(tzinfo=pytz.utc), {'datetime': '2014-04-01T02:03:04.567890'})
+    )
+    @ddt.unpack
+    def test_datetime_serialization(self, value, expected_attributes):
+        block_type = self.TestXBlockWithDateTime
+        block = self._make_block(block_type)
+        node = etree.Element(block_type.etree_node_tag)
+
+        block.datetime = value
+
+        block.add_xml_to_node(node)
+
+        self._assert_node_attributes(node, expected_attributes)

--- a/xblock/test/test_mixins.py
+++ b/xblock/test/test_mixins.py
@@ -152,11 +152,12 @@ class TestXmlSerializationMixin(TestCase):
 
         field = String()
         simple_default = String(default="default")
-        simple_default_with_force_export = String(default="default", force_export=True)
+        force_export = String(default="default", force_export=True)
         unique_id_default = String(default=UNIQUE_ID)
-        unique_id_default_with_force_export = String(default=UNIQUE_ID, force_export=True)
+        unique_id_force_export = String(default=UNIQUE_ID, force_export=True)
 
     class TestXBlockWithDateTime(XBlock):
+        """ XBlock for DateTime fields export """
         etree_node_tag = 'test_xblock_with_datetime'
 
         datetime = DateTime(default=None)
@@ -165,23 +166,27 @@ class TestXmlSerializationMixin(TestCase):
         """ Creates a test block """
         block_type = block_type if block_type else self.TestXBlock
         runtime_mock = mock.Mock(spec=Runtime)
-        scope_ids = ScopeIds("user_id", block_type.etree_node_tag, "def_id",  "usage_id")
+        scope_ids = ScopeIds("user_id", block_type.etree_node_tag, "def_id", "usage_id")
         return block_type(runtime_mock, field_data=DictFieldData({}), scope_ids=scope_ids)
 
-    def _assert_node_attributes(self, node, attributes):
+    def _assert_node_attributes(self, node, expected_attributes):
+        """ Checks XML node attributes to match expected_attributes"""
         node_attributes = node.keys()
         node_attributes.remove('xblock-family')
 
         self.assertEqual(node.get('xblock-family'), self.TestXBlock.entry_point)
-        self.assertEqual(set(node_attributes), set(attributes.keys()))
+        self.assertEqual(set(node_attributes), set(expected_attributes.keys()))
 
-        for key, value in attributes.iteritems():
+        for key, value in expected_attributes.iteritems():
             if value != UNIQUE_ID:
                 self.assertEqual(node.get(key), value)
             else:
                 self.assertIsNotNone(node.get(key))
 
     def test_add_xml_to_node(self):
+        """
+        Tests exporting block to XML
+        """
         block_type = self.TestXBlock
         block = self._make_block(block_type)
         node = etree.Element(block_type.etree_node_tag)
@@ -193,14 +198,14 @@ class TestXmlSerializationMixin(TestCase):
         block.add_xml_to_node(node)
 
         self._assert_node_attributes(
-            node, {'simple_default_with_force_export': 'default', 'unique_id_default_with_force_export': UNIQUE_ID}
+            node, {'force_export': 'default', 'unique_id_force_export': UNIQUE_ID}
         )
 
         block.field = 'Value1'
         block.simple_default = 'Value2'
-        block.simple_default_with_force_export = 'Value3'
+        block.force_export = 'Value3'
         block.unique_id_default = 'Value4'
-        block.unique_id_default_with_force_export = 'Value5'
+        block.unique_id_force_export = 'Value5'
 
         block.add_xml_to_node(node)
 
@@ -209,9 +214,9 @@ class TestXmlSerializationMixin(TestCase):
             {
                 'field': 'Value1',
                 'simple_default': 'Value2',
-                'simple_default_with_force_export': 'Value3',
+                'force_export': 'Value3',
                 'unique_id_default': 'Value4',
-                'unique_id_default_with_force_export': 'Value5',
+                'unique_id_force_export': 'Value5',
             }
         )
 
@@ -221,6 +226,9 @@ class TestXmlSerializationMixin(TestCase):
     )
     @ddt.unpack
     def test_datetime_serialization(self, value, expected_attributes):
+        """
+        Tests exporting DateTime fields to XML
+        """
         block_type = self.TestXBlockWithDateTime
         block = self._make_block(block_type)
         node = etree.Element(block_type.etree_node_tag)


### PR DESCRIPTION
**Description:** It is possible to set DateTime field to None (and not default), but exporting the course would fail in that case. This PR fixes this.

**Testing Instructions:**
1. Create an XBlock with DateTime field (or use existing one).
2. (Optional) Using StudioEditableXBlockMixin from xblock-utils makes it much easier by providing declarative interface to specifying what fields should be edited.
3. In studio, add the block to a course.
4. Set DateTime field to empty value (if using StudioEditableXBlockMixin - set any value with datetime dropdown, than clear it with backspace/delete. Do **not** reset to default.
5. Try exporting the course. _Pre-fix behavior:_ Exception is thrown. _Expected behavior:_ Course is successfully exported.
